### PR TITLE
Relax Timeouts Under Load

### DIFF
--- a/arcache-backend-memcached/src/test/java/ar/com/siripo/arcache/backend/memcached/ArcacheMemcachedClientTest.java
+++ b/arcache-backend-memcached/src/test/java/ar/com/siripo/arcache/backend/memcached/ArcacheMemcachedClientTest.java
@@ -43,7 +43,7 @@ public class ArcacheMemcachedClientTest {
 		HashSet<String> hs = new HashSet<String>();
 		hs.add("THEVALUE");
 
-		Future<Boolean> setFuture = memcachedClient.set("TESTMEMCACHEKEY", 10, hs);
+		Future<Boolean> setFuture = memcachedClient.set("TESTMEMCACHEKEY", 10000, hs);
 
 		try {
 			if (!setFuture.get(50, TimeUnit.MILLISECONDS).booleanValue()) {

--- a/arcache-core/src/main/java/ar/com/siripo/arcache/ArcacheClient.java
+++ b/arcache-core/src/main/java/ar/com/siripo/arcache/ArcacheClient.java
@@ -15,6 +15,7 @@ import ar.com.siripo.arcache.util.DummyFuture;
 public class ArcacheClient implements ArcacheClientInterface, BackendKeyBuilder {
 
 	protected long defaultOperationTimeoutMillis = 500;
+	protected boolean relaxOperationTimeoutInHeavyLoadSystem = true;
 	protected long timeMeasurementErrorMillis = 3000;
 	protected long defaultInvalidationWindowMillis = 5000;
 	protected boolean defaultHardInvalidation = true;
@@ -86,6 +87,16 @@ public class ArcacheClient implements ArcacheClientInterface, BackendKeyBuilder 
 	@Override
 	public long getDefaultOperationTimeoutMillis() {
 		return defaultOperationTimeoutMillis;
+	}
+
+	@Override
+	public void setRelaxOperationTimeoutInHeavyLoadSystem(boolean relaxOperationTimeoutInHeavyLoadSystem) {
+		this.relaxOperationTimeoutInHeavyLoadSystem = relaxOperationTimeoutInHeavyLoadSystem;
+	}
+
+	@Override
+	public boolean getRelaxOperationTimeoutInHeavyLoadSystem() {
+		return relaxOperationTimeoutInHeavyLoadSystem;
 	}
 
 	@Override

--- a/arcache-core/src/main/java/ar/com/siripo/arcache/ArcacheConfigurationGetInterface.java
+++ b/arcache-core/src/main/java/ar/com/siripo/arcache/ArcacheConfigurationGetInterface.java
@@ -7,6 +7,8 @@ public interface ArcacheConfigurationGetInterface {
 
 	public long getDefaultOperationTimeoutMillis();
 
+	public boolean getRelaxOperationTimeoutInHeavyLoadSystem();
+
 	public long getTimeMeasurementErrorMillis();
 
 	public long getDefaultInvalidationWindowMillis();

--- a/arcache-core/src/main/java/ar/com/siripo/arcache/ArcacheConfigurationSetInterface.java
+++ b/arcache-core/src/main/java/ar/com/siripo/arcache/ArcacheConfigurationSetInterface.java
@@ -13,6 +13,21 @@ public interface ArcacheConfigurationSetInterface {
 	public void setDefaultOperationTimeoutMillis(long timeoutMillis);
 
 	/**
+	 * In heavy loaded systems when CPU is at top, and with too many threads running
+	 * concurrently, the time measurements are imperfect, because the time is spend
+	 * in another thread and not in the IO operation. In that cases all the time on
+	 * a Get operation is spent in the first get of the object key. No timeout is
+	 * achieved but the seen time of the get operation is much higher than timeout
+	 * (a signal of overload or a backend bug). In this scenario if the object has
+	 * invalidation keys is a dilemma, 1. timeout the all the operation, possibly
+	 * adding more load to the system or 2. relax the timeout and get the
+	 * invalidation objects
+	 * 
+	 * @param relaxOperationTimeoutInHeavyLoadSystem (default true)
+	 */
+	public void setRelaxOperationTimeoutInHeavyLoadSystem(boolean relaxOperationTimeoutInHeavyLoadSystem);
+
+	/**
 	 * Error total en la medicion de tiempos expresado en mili segundos debe ser
 	 * 1000 + maxClockOffset + maxKeyCreationTime maxClockOffset (diferencia maxima
 	 * entre 2 relojes de la infraestructura involucrada) maxKeyCreationTime (Tiempo

--- a/arcache-core/src/main/java/ar/com/siripo/arcache/spring/ArcacheClientFactoryBean.java
+++ b/arcache-core/src/main/java/ar/com/siripo/arcache/spring/ArcacheClientFactoryBean.java
@@ -104,4 +104,9 @@ public class ArcacheClientFactoryBean
 		client.setInvalidationBackendClient(invalidationBackendClient);
 	}
 
+	@Override
+	public void setRelaxOperationTimeoutInHeavyLoadSystem(boolean relaxOperationTimeoutInHeavyLoadSystem) {
+		client.setRelaxOperationTimeoutInHeavyLoadSystem(relaxOperationTimeoutInHeavyLoadSystem);
+	}
+
 }

--- a/arcache-core/src/test/java/ar/com/siripo/arcache/ArcacheConfigurationInterfaceTest.java
+++ b/arcache-core/src/test/java/ar/com/siripo/arcache/ArcacheConfigurationInterfaceTest.java
@@ -1,6 +1,8 @@
 package ar.com.siripo.arcache;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Before;
@@ -28,6 +30,16 @@ public class ArcacheConfigurationInterfaceTest {
 			fail();
 		} catch (IllegalArgumentException e) {
 		}
+	}
+
+	@Test
+	public void testSetRelaxOperationTimeoutInHeavyLoadSystem() {
+		assertTrue("RelaxOperationTimeoutInHeavyLoadSystem default is expected to be true",
+				config.getRelaxOperationTimeoutInHeavyLoadSystem());
+		config.setRelaxOperationTimeoutInHeavyLoadSystem(false);
+		assertFalse(config.getRelaxOperationTimeoutInHeavyLoadSystem());
+		config.setRelaxOperationTimeoutInHeavyLoadSystem(true);
+		assertTrue(config.getRelaxOperationTimeoutInHeavyLoadSystem());
 	}
 
 	@Test

--- a/arcache-core/src/test/java/ar/com/siripo/arcache/spring/ArcacheClientFactoryBeanTest.java
+++ b/arcache-core/src/test/java/ar/com/siripo/arcache/spring/ArcacheClientFactoryBeanTest.java
@@ -147,4 +147,12 @@ public class ArcacheClientFactoryBeanTest {
 		assertEquals(bc, factoryBean.getObject().getInvalidationBackendClient());
 	}
 
+	@Test
+	public void testSetRelaxOperationTimeoutInHeavyLoadSystem() throws Exception {
+		factoryBean.setRelaxOperationTimeoutInHeavyLoadSystem(false);
+		assertEquals(false, factoryBean.getObject().getRelaxOperationTimeoutInHeavyLoadSystem());
+		factoryBean.setRelaxOperationTimeoutInHeavyLoadSystem(true);
+		assertEquals(true, factoryBean.getObject().getRelaxOperationTimeoutInHeavyLoadSystem());
+	}
+
 }


### PR DESCRIPTION
Adds a feature to enable relax timeouts when the system is under load to allow load Invalidation Objects